### PR TITLE
updated files to support HTTPS

### DIFF
--- a/xpost_comments.php
+++ b/xpost_comments.php
@@ -19,9 +19,11 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
+include 'wordpress/wp-load.php';
 
 require_once( 'xpost_config.php' );
 require_once( ABSPATH . WPINC . '/class-IXR.php' );
+require_once ( ABSPATH . WPINC . '/class-wp-http-ixr-client.php');
 
 add_action( 'wp_set_comment_status', 'crosspost_comment', 10, 2 );
 add_action( 'comment_post', 'crosspost_fresh_comment', 10, 2 );
@@ -61,7 +63,7 @@ function crosspost_comment( $id, $approved ) {
 		$commentToken = get_post_meta( $comment->comment_post_ID, '_xpost_comment_token', true );
 		$excludeId = get_post_meta( $comment->comment_post_ID, '_xpost_comment_exclude_id', true );
 		$originalPost = get_post_meta( $comment->comment_post_ID, '_xpost_original_postid', true );
-		$client = new IXR_Client( $broadcastUrl );
+		$client = new WP_HTTP_IXR_CLIENT( $broadcastUrl );
 		$client->query( 'xpost.broadcastComment', $commentToken, $originalPost, $excludeId, $commentData );
 	}
 	
@@ -79,7 +81,7 @@ function crosspost_comment( $id, $approved ) {
 		$sql = "SELECT blogid, xmlrpc, user, password FROM ".XPOST_TABLE_NAME." WHERE id = $blog->id";
 		$blogUserData = $wpdb->get_row( $sql );
 		
-		$client = new IXR_Client( $blogUserData->xmlrpc );
+		$client = new WP_HTTP_IXR_CLIENT( $blogUserData->xmlrpc );
 		$client->query( 'xpost.newComment', $blogUserData->blogid, $blogUserData->user, $blogUserData->password, $blog->remote_postid, $commentData );
 	}
 }

--- a/xpost_options.php
+++ b/xpost_options.php
@@ -19,9 +19,11 @@
     along with this program; if not, write to the Free Software
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
+include 'wordpress/wp-load.php';
 
 require_once( 'xpost_config.php' );
 require_once( ABSPATH . WPINC . '/class-IXR.php' );
+require_once ( ABSPATH . WPINC . '/class-wp-http-ixr-client.php');
 
 add_action( 'admin_menu', 'xpost_plugin_menu' );
 
@@ -85,7 +87,7 @@ function xpost_options_page() {
 		}
 		
 		/* Check whether XML-RPC connection works */
-		$client = @new IXR_Client( $xmlrpc );
+		$client = @new WP_HTTP_IXR_CLIENT( $xmlrpc );
 		if( $xpost_community_server ) {
 			$success = $client->query( 'blogger.getUsersBlogs', $user, $user, $password );
 		} else {

--- a/xpost_post.php
+++ b/xpost_post.php
@@ -20,6 +20,9 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+include 'wordpress/wp-load.php';
+require_once ABSPATH . WPINC . '/class-IXR.php';
+require_once ABSPATH . WPINC . '/class-wp-http-ixr-client.php';
 require_once( ABSPATH . '/wp-includes/post.php' );
 
 add_action( 'save_post', 'xpost_crosspost' );
@@ -157,7 +160,7 @@ function xpost_crosspost( $localPostId ) {
 			$publish = ($_POST['post_status'] == 'publish');
 			
 			$updateDb = false;
-			$client = new IXR_Client( $blog->xmlrpc );
+			$client = new WP_HTTP_IXR_CLIENT( $blog->xmlrpc );
 			if( !$createNew ) {
 				$client->query( 'metaWeblog.editPost', $post->remote_postid, $blog->user, $blog->password, $postData, $publish );
 				$response = $client->getResponse();

--- a/xpost_widget.php
+++ b/xpost_widget.php
@@ -20,8 +20,12 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+include 'wordpress/wp-load.php';
+
 require_once( 'xpost_config.php' );
 require_once( ABSPATH . WPINC . '/class-IXR.php' );
+require_once ( ABSPATH . WPINC . '/class-wp-http-ixr-client.php');
+
 
 add_action( 'admin_menu', 'xpost_add_widget' );
 add_action( 'wp_ajax_xpost_get_categories', 'xpost_get_categories' );
@@ -142,7 +146,7 @@ function xpost_get_categories_cs( $blog )
 	
 
 	/* Fetch categories */
-	$client = @new IXR_Client( $blog->xmlrpc );
+	$client = @new WP_HTTP_IXR_CLIENT( $blog->xmlrpc );
 	$success = $client->query( 'metaWeblog.getCategories',  $blog->user, $blog->user, $blog->password );
 	$response = $client->getResponse();	;
 	
@@ -216,7 +220,7 @@ function xpost_get_categories_wp( $blog )
 	$postId = intval( $_POST['postid'] );
 	
 	/* Fetch categories */
-	$client = @new IXR_Client( $blog->xmlrpc );
+	$client = @new WP_HTTP_IXR_CLIENT( $blog->xmlrpc );
 	//echo json_encode($blog);
 	$success = $client->query( 'wp.getCategories', $blog->blogid, $blog->user, $blog->password );
 	$response = $client->getResponse();	;

--- a/xpost_xmlrpc.php
+++ b/xpost_xmlrpc.php
@@ -20,8 +20,11 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+include 'wordpress/wp-load.php';
+
 include_once(ABSPATH . WPINC . '/comment.php');
-include_once(ABSPATH . WPINC . '/class-IXR.php');
+require_once( ABSPATH . WPINC . '/class-IXR.php' );
+require_once ( ABSPATH . WPINC . '/class-wp-http-ixr-client.php');
 
 add_filter( 'xmlrpc_methods', 'xpost_add_xmlrpc_methods' );
 
@@ -90,7 +93,7 @@ class xpost_xmlrpc {
 				$sql = "SELECT blogid, xmlrpc, user, password FROM ".XPOST_TABLE_NAME." WHERE id = $blog->id";
 				$blogUserData = $wpdb->get_row( $sql );
 			
-				$client = new IXR_Client( $blogUserData->xmlrpc );
+				$client = new WP_HTTP_IXR_CLIENT( $blogUserData->xmlrpc );
 				$client->query( 'xpost.newComment', $blogUserData->blogid, $blogUserData->user, $blogUserData->password, $blog->remote_postid, $commentData );
 			}
 		}


### PR DESCRIPTION
IXR_Client does not support HTTPS (uses plain TCP connection) and produces strange errors in the process. Therefore, I adapted it to use class-wp-http-ixr-client which supports HTTP and HTTPS.